### PR TITLE
Update WordPress.php -- Add "httpdocs" in addition to "src" for root dir

### DIFF
--- a/library/DeltaCli/Template/WordPress.php
+++ b/library/DeltaCli/Template/WordPress.php
@@ -106,7 +106,7 @@ class WordPress implements TemplateInterface
 
             if (file_exists($cwd . '/src')) {
                 $this->localWordPressRoot = $cwd . '/src';
-            } else if (file_exists($cwd . 'httpdocs')) {
+            } else if (file_exists($cwd . '/httpdocs')) {
                 $this->localWordPressRoot = $cwd . '/httpdocs';
             } else {
                 $this->localWordPressRoot = $cwd;

--- a/library/DeltaCli/Template/WordPress.php
+++ b/library/DeltaCli/Template/WordPress.php
@@ -106,6 +106,8 @@ class WordPress implements TemplateInterface
 
             if (file_exists($cwd . '/src')) {
                 $this->localWordPressRoot = $cwd . '/src';
+            } else if (file_exists($cwd . 'httpdocs')) {
+                $this->localWordPressRoot = $cwd . '/httpdocs';
             } else {
                 $this->localWordPressRoot = $cwd;
             }


### PR DESCRIPTION
Some of our repos root directories are "httpdocs", not "src"