### PR TITLE
Use stream handler for Guzzle HTTP client

### DIFF
--- a/library/DeltaCli/ApiClient.php
+++ b/library/DeltaCli/ApiClient.php
@@ -3,6 +3,8 @@
 namespace DeltaCli;
 
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\StreamHandler;
+use GuzzleHttp\HandlerStack;
 
 class ApiClient
 {
@@ -22,7 +24,10 @@ class ApiClient
 
     public function __construct(GuzzleClient $guzzleClient = null)
     {
-        $this->guzzleClient = ($guzzleClient ?: new GuzzleClient(['exceptions' => false]));
+        $stack = new HandlerStack();
+        $stack->setHandler(new StreamHandler());
+
+        $this->guzzleClient = ($guzzleClient ?: new GuzzleClient(['exceptions' => false, 'handler' => $stack]));
         $this->homeFolder   = $_SERVER['HOME'];
     }
 


### PR DESCRIPTION
This enables the API client to work in environments without cURL or having older versions of libcurl that are incompatible with server SSL/TLS version