### PR TITLE
Added Git Branch to env:list output

### DIFF
--- a/library/DeltaCli/Command/ListEnvironments.php
+++ b/library/DeltaCli/Command/ListEnvironments.php
@@ -41,7 +41,7 @@ class ListEnvironments extends Command
             $this->displayNoEnvironmentsBanner($output);
         } else {
             $table = new Table($output);
-            $table->setHeaders(['Name', 'Host(s)', 'Is Dev Environment?']);
+            $table->setHeaders(['Name', 'Host(s)', 'Is Dev Environment?', 'Git Branch']);
             $table->setRows($this->getEnvironmentTableRows($environments));
             $table->render();
         }
@@ -77,7 +77,8 @@ class ListEnvironments extends Command
             $rows[] = [
                 $environment->getName(),
                 implode(PHP_EOL, $hosts),
-                $environment->isDevEnvironment() ? 'Yes' : 'No'
+                $environment->isDevEnvironment() ? 'Yes' : 'No',
+                $environment->getGitBranch()
             ];
         }
 


### PR DESCRIPTION
Simple change, adding one column to list-environments output. Shows associated git branch for an environment (blank if none configured).