### PR TITLE
Ensure creation of vhost script was successful; throw descriptive error if not

### DIFF
--- a/library/DeltaCli/Extension/Vagrant/Exception/VirtualHostConfigurationCannotBeSaved.php
+++ b/library/DeltaCli/Extension/Vagrant/Exception/VirtualHostConfigurationCannotBeSaved.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DeltaCli\Extension\Vagrant\Exception;
+
+use Exception;
+
+class VirtualHostConfigurationCannotBeSaved extends Exception
+{
+
+}

--- a/library/DeltaCli/Extension/Vagrant/Script/CreateVhost.php
+++ b/library/DeltaCli/Extension/Vagrant/Script/CreateVhost.php
@@ -4,6 +4,7 @@ namespace DeltaCli\Extension\Vagrant\Script;
 
 use DeltaCli\Console\Output\Banner;
 use DeltaCli\Extension\Vagrant\Exception\VirtualHostConfigurationAlreadyExists;
+use DeltaCli\Extension\Vagrant\Exception\VirtualHostConfigurationCannotBeSaved;
 use DeltaCli\FileTemplate;
 use DeltaCli\Project;
 use DeltaCli\Script;
@@ -114,6 +115,12 @@ class CreateVhost extends Script
                         ->assign('docRoot', $this->documentRoot)
                         ->assign('applicationEnv', $this->applicationEnv);
                     $template->write($apachePath);
+
+                    if (!file_exists($apachePath)) {
+                        throw new VirtualHostConfigurationCannotBeSaved(
+                            "delta-cli was unable to save virtual host configuration at {$apachePath}. Check your privilidges?"
+                        );
+                    }
                 }
             )
             ->addStep(
@@ -124,6 +131,12 @@ class CreateVhost extends Script
                         ->assign('hostname', $this->hostname)
                         ->assign('docRoot', $this->documentRoot);
                     $template->write($nginxPath);
+
+                    if (!file_exists($nginxPath)) {
+                        throw new VirtualHostConfigurationCannotBeSaved(
+                            "delta-cli was unable to save virtual host configuration at {$nginxPath}. Check your privilidges?"
+                        );
+                    }
                 }
             )
             ->addStep(


### PR DESCRIPTION
`vagrant:create-vhost` is checking to see if the vhost files already exists and throwing an error if so, but it isn't currently checking to see if the files were successfully created. Even without the files successfully created, `vagrant:create-vhost` completes successfully. This commit fixes #16.